### PR TITLE
Bug fix - file button shows up when screen is vastly larger than 1000 pixels in the vertical space

### DIFF
--- a/javascript/JZZ.gui.Player.js
+++ b/javascript/JZZ.gui.Player.js
@@ -161,7 +161,7 @@
       self.fileInput = document.createElement('input');
       self.fileInput.type = 'file';
       self.fileInput.style.position = 'fixed';
-      self.fileInput.style.top = '-1000px';
+      self.fileInput.style.visibility = 'hidden';
       self.fileInput.accept = '.mid, .midi, .kar, .rmi, .syx';
       self.gui.appendChild(self.fileInput);
 


### PR DESCRIPTION
If the input button/widget is below 1000px, the input button starts showing.

Need to instead just disable visibility on it.